### PR TITLE
fix(app-ext): add publicPath config setting

### DIFF
--- a/app-extension/src/boot/qpdfviewer.js
+++ b/app-extension/src/boot/qpdfviewer.js
@@ -1,5 +1,5 @@
 import QPdfviewer from '@quasar/quasar-app-extension-qpdfviewer/src/component/QPdfviewer.js'
 
-export default ({ app }) => {
-  app.component('QPdfviewer', QPdfviewer)
+export default ({ app, publicPath }) => {
+  app.component('QPdfviewer', QPdfviewer({ publicPath }))
 }

--- a/app-extension/src/component/QPdfviewer.js
+++ b/app-extension/src/component/QPdfviewer.js
@@ -11,7 +11,7 @@
 
 import { defineComponent, h } from "vue"
 
-export default defineComponent({
+export default (config) => defineComponent({
   name: "QPdfviewer",
 
   props: {
@@ -72,7 +72,7 @@ export default defineComponent({
       return h('iframe', {
         // Change to new format style for Vue3
         class: ['q-pdfviewer__iframe'],
-        src: '/pdfjs/web/viewer.html?file=' + encodeURIComponent(props.src),
+        src: config.publicPath + 'pdfjs/web/viewer.html?file=' + encodeURIComponent(props.src),
         width: '100%',
         height: '100%'
       }, [


### PR DESCRIPTION
This pull request addresses discussion #122 and issue #123 by refactoring the global component registration to a factory function. This function passes the publicPath configuration value from the boot file to the component's render function. Consequently, the rendering is now correctly aligned with non-root `publicPath` setting in `quasar.config.js` and also works when using vue router history mode. This should ensure correct rendering when the project is hosted in subdirectories, such as /some/nested/dir/.