### PR TITLE
[Fix] Compatibility with @quasar/app-vite 

### DIFF
--- a/app-extension/src/index.js
+++ b/app-extension/src/index.js
@@ -25,7 +25,7 @@ module.exports = function (api) {
   api.compatibleWith('quasar', '^2.0.0')
 
   if (api.hasVite === true) {
-    api.compatibleWith('@quasar/app-vite', '^1.0.0-alpha.0')
+    api.compatibleWith('@quasar/app-vite', '^2.0.0-alpha.0')
   }
   else {
     // should be "@quasar/app-webpack" but that is not backward compatible


### PR DESCRIPTION
This Pull Request addresses the issue with [App Vite ^v2](https://github.com/quasarframework/app-extension-qpdfviewer/issues/136)

Describtion of the bug
Extension(@quasar/qpdfviewer): is not compatible with @quasar/app-vite v2.0.0-beta.3. Required version: ^1.0.0-alpha.0